### PR TITLE
Add event photo carousel

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -132,3 +132,20 @@ footer {
   flex: 1 1 50%;
   text-align: center;
 }
+
+/* Carousel Section */
+.carousel-section {
+  background: linear-gradient(to bottom, #8E44AD, #2b0a11);
+  border-radius: 1rem;
+  padding: 2rem;
+  margin: 3rem auto;
+  max-width: 1080px;
+}
+
+.carousel-section .carousel-item img {
+  width: 100%;
+  height: auto;
+  max-height: 600px;
+  object-fit: cover;
+  border-radius: 1rem;
+}

--- a/index.html
+++ b/index.html
@@ -15,6 +15,48 @@
     <h1>Where Craft, Community & Medicine Meet</h1>
   </section>
 
+  <!-- Event Carousel -->
+  <section class="section carousel-section">
+    <div id="eventCarousel" class="carousel slide" data-bs-ride="carousel">
+      <div class="carousel-indicators">
+        <button type="button" data-bs-target="#eventCarousel" data-bs-slide-to="0" class="active" aria-current="true" aria-label="Slide 1"></button>
+        <button type="button" data-bs-target="#eventCarousel" data-bs-slide-to="1" aria-label="Slide 2"></button>
+        <button type="button" data-bs-target="#eventCarousel" data-bs-slide-to="2" aria-label="Slide 3"></button>
+        <button type="button" data-bs-target="#eventCarousel" data-bs-slide-to="3" aria-label="Slide 4"></button>
+        <button type="button" data-bs-target="#eventCarousel" data-bs-slide-to="4" aria-label="Slide 5"></button>
+        <button type="button" data-bs-target="#eventCarousel" data-bs-slide-to="5" aria-label="Slide 6"></button>
+      </div>
+      <div class="carousel-inner">
+        <div class="carousel-item active">
+          <img src="media/eventPhotos/F2F081D9-A422-4465-96A7-D43BEC58D1C2.jpeg" class="d-block w-100" alt="Attendees enjoying the event">
+        </div>
+        <div class="carousel-item">
+          <img src="media/eventPhotos/IMG_5020.jpeg" class="d-block w-100" alt="Outdoor gathering crowd">
+        </div>
+        <div class="carousel-item">
+          <img src="media/eventPhotos/dj-performing-at-indoor-event.jpg" class="d-block w-100" alt="DJ performing indoors">
+        </div>
+        <div class="carousel-item">
+          <img src="media/eventPhotos/fregrwli-vendor-table-at-event.jpg" class="d-block w-100" alt="Vendor table display">
+        </div>
+        <div class="carousel-item">
+          <img src="media/eventPhotos/three-men-posing-in-event-doorway.jpg" class="d-block w-100" alt="Group posing in doorway">
+        </div>
+        <div class="carousel-item">
+          <img src="media/eventPhotos/third-eye-craft-selfie-with-poster.jpg" class="d-block w-100" alt="Selfie with event poster">
+        </div>
+      </div>
+      <button class="carousel-control-prev" type="button" data-bs-target="#eventCarousel" data-bs-slide="prev">
+        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Previous</span>
+      </button>
+      <button class="carousel-control-next" type="button" data-bs-target="#eventCarousel" data-bs-slide="next">
+        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+        <span class="visually-hidden">Next</span>
+      </button>
+    </div>
+  </section>
+
   <!-- Welcome / Vibe Check -->
   <section class="section text-block">
     <h2>A Celebration of Creative Medicine</h2>


### PR DESCRIPTION
## Summary
- showcase event pictures with a new Bootstrap carousel on the homepage
- style carousel images with new CSS rules

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848590f09c88324951c1d16bd185996